### PR TITLE
Increase max configurable battery to 10 kWh

### DIFF
--- a/firmware/common/src/configscreen.c
+++ b/firmware/common/src/configscreen.c
@@ -43,7 +43,7 @@ static Field batterySOCMenus[] =
 {
 	FIELD_EDITABLE_ENUM("Text", &ui_vars.ui8_battery_soc_enable, "disable", "SOC %", "volts"),
 	FIELD_EDITABLE_UINT(_S("Reset at voltage", "Reset at"), &ui_vars.ui16_battery_voltage_reset_wh_counter_x10, "volts", 160, 630, .div_digits = 1),
-	FIELD_EDITABLE_UINT(_S("Battery total Wh", "Batt total"), &ui_vars.ui32_wh_x10_100_percent, "whr", 0, 19990, .div_digits = 1, .inc_step = 100),
+	FIELD_EDITABLE_UINT(_S("Battery total Wh", "Batt total"), &ui_vars.ui32_wh_x10_100_percent, "whr", 0, 99990, .div_digits = 1, .inc_step = 100),
 	FIELD_EDITABLE_UINT("Used Wh", &ui_vars.ui32_wh_x10, "whr", 0, 99900, .div_digits = 1, .inc_step = 10, .onSetEditable = onSetConfigurationBatterySOCUsedWh),
 	FIELD_EDITABLE_ENUM(_S("Manual reset", "Manual rst"), &ui8_g_configuration_battery_soc_reset, "no", "yes"),
 	FIELD_END };


### PR DESCRIPTION
I have a 48V 60Ah battery, which is good for about 150km, and I can imagine hauling cargo the whole day or touring could use twice or three times as much easily.